### PR TITLE
fix: duplicate normalized requests

### DIFF
--- a/queen.go
+++ b/queen.go
@@ -214,8 +214,6 @@ func (q *Queen) Run(ctx context.Context) error {
 			return ctx.Err()
 		case <-crawlTime.C:
 			q.routine(ctx)
-		case <-ctx.Done():
-			q.persistLiveAntsKeys()
 		}
 	}
 }


### PR DESCRIPTION
Handles the request normalization similar to `consumeAntsLogs`. Now we won't run the risk of starting multiple normalization procedures at once. The normalization ticker drops ticks for slow receivers, which is fine as well.

This change is untested. It would be great if you @kasteph or @guillaumemichel could briefly run it locally to verify that it works.