### PR TITLE
fix: retrieve ant privkey

### DIFF
--- a/ant.go
+++ b/ant.go
@@ -23,8 +23,9 @@ const (
 )
 
 type Ant struct {
-	port uint16
-	dht  *kad.IpfsDHT
+	port    uint16
+	dht     *kad.IpfsDHT
+	privKey crypto.PrivKey
 
 	Host      host.Host
 	KadId     bit256.Key
@@ -83,6 +84,7 @@ func SpawnAnt(ctx context.Context, privKey crypto.PrivKey, peerstore peerstore.P
 	ant := &Ant{
 		Host:      h,
 		dht:       dht,
+		privKey:   privKey,
 		KadId:     PeeridToKadid(h.ID()),
 		port:      port,
 		UserAgent: userAgent,

--- a/queen.go
+++ b/queen.go
@@ -374,9 +374,10 @@ func (q *Queen) routine(ctx context.Context) {
 	// remove ants
 	returnedKeys := make([]crypto.PrivKey, len(excessAntsIndices))
 	for i, index := range excessAntsIndices {
-		returnedKeys[i] = q.ants[index].Host.Peerstore().PrivKey(q.ants[index].Host.ID())
-		port := q.ants[index].port
-		q.ants[index].Close()
+		ant := q.ants[index]
+		returnedKeys[i] = ant.privKey
+		port := ant.port
+		ant.Close()
 		q.ants = append(q.ants[:index], q.ants[index+1:]...)
 		q.freePort(port)
 	}


### PR DESCRIPTION
* `privkey` is now stored on the ant, since retrieving it from the peerstore doesn't always work.