### PR TITLE
fix: default "" str for trace host and 0 for port

### DIFF
--- a/queen.go
+++ b/queen.go
@@ -99,7 +99,7 @@ func NewQueen(ctx context.Context, dbConnString string, keysDbPath string, nPort
 }
 
 func getDbClient(ctx context.Context) *db.DBClient {
-	dbPort, err := getEnvInt("DB_PORT", 6667)
+	dbPort, err := getEnvInt("DB_PORT", 5432)
 	if err != nil {
 		logger.Errorf("Port must be an integer: %w", err)
 	}

--- a/queen.go
+++ b/queen.go
@@ -99,31 +99,28 @@ func NewQueen(ctx context.Context, dbConnString string, keysDbPath string, nPort
 }
 
 func getDbClient(ctx context.Context) *db.DBClient {
-	dbPort, err := strconv.Atoi(os.Getenv("DB_PORT"))
+	dbPort, err := getEnvInt("DB_PORT", 6667)
 	if err != nil {
 		logger.Errorf("Port must be an integer: %w", err)
 	}
-
 	mP, _ := tele.NewMeterProvider()
 
 	tracesHost, tracesHostSet := os.LookupEnv("TRACES_HOST")
 	if !tracesHostSet {
-		tracesHost = "0.0.0.0"
+		tracesHost = ""
 	}
-	tracesPort, tracesPortSet := os.LookupEnv("TRACES_PORT")
-	if !tracesPortSet {
-		tracesPort = "6667"
-	}
-	tracesPortAsInt, err := strconv.Atoi(tracesPort)
+	tracesPort, err := getEnvInt("TRACES_PORT", 0)
 	if err != nil {
 		logger.Errorf("Port must be an integer: %w", err)
 	}
-
-	tP, _ := tele.NewTracerProvider(
+	tP, err := tele.NewTracerProvider(
 		ctx,
 		tracesHost,
-		tracesPortAsInt,
+		tracesPort,
 	)
+	if err != nil {
+		logger.Errorf("new tracer provider: %w", err)
+	}
 
 	dbc, err := db.InitDBClient(ctx, &config.Database{
 		DatabaseHost:           os.Getenv("DB_HOST"),
@@ -330,7 +327,7 @@ func (q *Queen) persistLiveAntsKeys() {
 func (q *Queen) routine(ctx context.Context) {
 	networkPeers, err := q.nebulaDB.GetLatestPeerIds(ctx)
 	if err != nil {
-		logger.Warn("unable to get latest peer ids from Nebula", err)
+		logger.Warn("unable to get latest peer ids from Nebula ", err)
 		return
 	}
 

--- a/util.go
+++ b/util.go
@@ -1,6 +1,9 @@
 package ants
 
 import (
+	"fmt"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -52,4 +55,18 @@ func bitstrToBit256(strKey bitstr.Key, padding []byte) bit256.Key {
 		bit256Key[i/8] = currByte
 	}
 	return bit256.NewKey(bit256Key)
+}
+
+func getEnvInt(key string, defaultValue int) (int, error) {
+	value, exists := os.LookupEnv(key)
+	if !exists {
+		return defaultValue, nil
+	}
+
+	result, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an int: %w", key, err)
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
- sets a default port of `5432` for the ants database
- sets an empty string `""` for host and `0` for port for the traces which disables it