### PR TITLE
fix: limit results from requests_denormalized table

### DIFF
--- a/db/client_db.go
+++ b/db/client_db.go
@@ -613,7 +613,7 @@ func BulkInsertRequests(ctx context.Context, db *sql.DB, requests []models.Reque
 }
 
 func NormalizeRequests(ctx context.Context, db *sql.DB, dbClient *DBClient) error {
-	rows, err := db.QueryContext(ctx, "SELECT id, request_started_at, request_type, ant_multihash, peer_multihash, key_multihash, multi_addresses, agent_version, protocols FROM requests_denormalized WHERE normalized_at IS NULL")
+	rows, err := db.QueryContext(ctx, "SELECT id, request_started_at, request_type, ant_multihash, peer_multihash, key_multihash, multi_addresses, agent_version, protocols FROM requests_denormalized WHERE normalized_at IS NULL LIMIT 1000")
 	if err != nil {
 		return err
 	}

--- a/db/migrations/000021_create_index_idx_normalized_at_is_null.down.sql
+++ b/db/migrations/000021_create_index_idx_normalized_at_is_null.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_normalized_at_is_null;

--- a/db/migrations/000021_create_index_idx_normalized_at_is_null.up.sql
+++ b/db/migrations/000021_create_index_idx_normalized_at_is_null.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_normalized_at_is_null
+ON requests_denormalized (normalized_at)
+WHERE normalized_at IS NULL;


### PR DESCRIPTION
- added a partial/covered index on the `normalized_at` column to speed up fetching rows yet to be normalized
- limit result set to 1000 since it would be too many otherwise. this takes too long (longer than the normalization time interval), which leads to a backlog of rows to be normalized.