### PR TITLE
fix: remove normalization

### DIFF
--- a/queen.go
+++ b/queen.go
@@ -206,7 +206,6 @@ func (q *Queen) Run(ctx context.Context) error {
 	defer logger.Debugln("Queen.Run completing")
 
 	go q.consumeAntsLogs(ctx)
-	go q.normalizeRequests(ctx)
 
 	crawlTime := time.NewTicker(CRAWL_INTERVAL)
 	defer crawlTime.Stop()
@@ -295,29 +294,6 @@ func (q *Queen) consumeAntsLogs(ctx context.Context) {
 		default:
 			// against busy-looping since <-q.antsLogs is a busy chan
 			time.Sleep(10 * time.Millisecond)
-		}
-	}
-}
-
-func (q *Queen) normalizeRequests(ctx context.Context) {
-	logger.Info("Starting continuous normalization...")
-
-	normalizationTime := time.NewTicker(NORMALIZATION_INTERVAL)
-	defer normalizationTime.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-normalizationTime.C:
-			// fall through
-		}
-
-		err := db.NormalizeRequests(ctx, q.dbc.Handler, q.dbc)
-		if err != nil {
-			logger.Errorf("Error during normalization: %s", err)
-		} else {
-			logger.Info("Normalization completed for current batch.")
 		}
 	}
 }

--- a/util.go
+++ b/util.go
@@ -17,9 +17,8 @@ import (
 )
 
 const (
-	CRAWL_INTERVAL         = 30 * time.Minute
-	NORMALIZATION_INTERVAL = 60 * time.Second
-	BUCKET_SIZE            = 20
+	CRAWL_INTERVAL = 30 * time.Minute
+	BUCKET_SIZE    = 20
 )
 
 func PeeridToKadid(pid peer.ID) bit256.Key {


### PR DESCRIPTION
Follow up to https://github.com/probe-lab/ants-watch/pull/21

Since the normalization process isn't able to keep up with the number of requests, we use the `denormalized_requests` for data analysis. The normalization process isn't needed anymore IIUC. 