### PR TITLE
add: local development setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ keys.db
 log.txt
 *.dat
 *.mmdb
+
+db/migrations/local

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REPO_REGION?=us-east-1
 
 
 tools:
-	go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.15.2
+	go install -tags 'postgres,clickhouse' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.15.2
 
 non-cluster-migrations:
 	mkdir -p db/migrations/local

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,21 @@ REPO_REGION?=us-east-1
 tools:
 	go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.15.2
 
-migrate-up:
-	migrate -database 'clickhouse://localhost:9000?username=default&secure=false' -path db/migrations up
+non-cluster-migrations:
+	mkdir -p db/migrations/local
+	for file in $(shell find db/migrations -maxdepth 1 -name "*.sql"); do \
+	  filename=$$(basename $$file); \
+	  sed 's/Replicated//' $$file > db/migrations/local/$$filename; \
+	done
 
-migrate-down:
-	migrate -database 'clickhouse://localhost:9000?username=default&secure=false' -path db/migrations down
+local-migrate-up: non-cluster-migrations
+	migrate -database 'clickhouse://localhost:9000?username=ants_local&database=ants_local&password=password&x-multi-statement=true' -path db/migrations/local up
+
+local-migrate-down: non-cluster-migrations
+	migrate -database 'clickhouse://localhost:9000?username=ants_local&database=ants_local&password=password&x-multi-statement=true' -path db/migrations/local down
 
 local-clickhouse:
-	docker run --name ants-clickhouse --rm -p 9000:9000 clickhouse/clickhouse-server
+	docker run --name ants-clickhouse --rm -p 9000:9000 -e CLICKHOUSE_DB=ants_local -e CLICKHOUSE_USER=ants_local -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 -e CLICKHOUSE_PASSWORD=password clickhouse/clickhouse-server
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -38,45 +38,38 @@ git submodule init
 git submodule update --init --recursive --remote
 ```
 
-Then, `go mod tidy`.
-
 You'll also need to install some tools: `make tools`.
 
-You need to setup a postgres database with:
+You need to setup a Clickhouse database with:
 
-* username: `ants-watch`
-* password: `password` <-- you should change this in the [Makefile](./Makefile)
-* database: `ants-watch`
+```shell
+make local-clickhouse
+```
 
-Migrations can now be applied: `make migrate-up`.
+This will start a Clickhouse server with the container name `ants-clickhouse` that's accessible on the non-SSL native port `9000`. Further database parameters are:
+
+* username: `ants_local`
+* password: `password`
+* database: `ants_local`
+
+Then you need to apply the migrations with:
+
+```shell
+make local-migrate-up
+```
 
 ## Configuration
 
-The following environment variables should be set:
+The following environment variables should be set for ants-watch:
 
 ```sh
-DB_HOST=localhost
-DB_PORT=5432
-DB_DATABASE=ants-watch
-DB_USER=ants-watch
-DB_PASSWORD=password
-DB_SSLMODE=disable
+ANTS_CLICKHOUSE_ADDRESS=localhost:9000
+ANTS_CLICKHOUSE_DATABASE=ants_local
+ANTS_CLICKHOUSE_USERNAME=ants_local
+ANTS_CLICKHOUSE_PASSWORD=password
+ANTS_CLICKHOUSE_SSL=false
 
-NEBULA_POSTGRES_CONNURL=postgres://nebula:password@localhost/nebula?sslmode=disable
-
-UDGER_FILEPATH=/location/to/udgerdb.dat               # optional, used to detect datacenters
-MAXMIND_ASN_DB=/location/to/GeoLite2-ASN.mmdb         # optional, used to extract ASN from IP
-MAXMIND_COUNRTY_DB=/location/to/GeoLite2-Country.mmdb # optional, used to extract country from IP
-
-KEY_DB_PATH=/location/to/keys.db  # optional, used to store the generated libp2p keys
-
-METRICS_HOST=0.0.0.0  # optional, used to expose metrics
-METRICS_PORT=6666     # optional, used to expose metrics
-
-TRACES_HOST=0.0.0.0   # optional, used to expose traces
-TRACES_PORT=6667      # optional, used to expose traces
-
-BATCH_TIME=20 # optional, time in seconds between each batch of requests
+ANTS_NEBULA_CONNSTRING=postgres://nebula:password@localhost/nebula?sslmode=disable # change with proper values for the datbase you want to use
 ```
 
 ## Usage
@@ -90,9 +83,9 @@ Once the database is setup and migrations are applied, you can start the honeypo
 In [`cmd/honeypot/`](./cmd/honeypot/), you can run the following command:
 
 ```sh
-go run . queen -upnp=true # for UPnP
+go run ./cmd/ants queen --upnp # for UPnP
 # or
-go run . queen -firstPort=<port> -nPorts=<count> # for port forwarding
+go run ./cmd/ants queen --first_port=<port> --num_ports=<count> # for port forwarding
 ```
 
 When UPnP is disabled, ports from `firstPort` to `firstPort + nPorts - 1` must be forwarded to the machine running `ants-watch`. `ants-watch` will be able to spawn at most `nPorts` distinct `ants`.


### PR DESCRIPTION
Adds setup instructions for local development. The issue here is that our production clickhouse database operates in "clustered" mode. This means we need to use the `Replicated` merge tree variants. You can see in the migration that we use the `ENGINE = ReplicatedMergeTree`. However, when running locally we cannot apply this migration because when we run a single Clickhouse instance we need to use the plaing `MergeTree` engine.

In this PR I just remove all occurences of the string `Replicated` with an empty string `` from the migrations and put the resulting files in a `local` subdirectory which is excluded from git. When running `local-migrate-up` go-migrate will look into this subdirectory and apply the migrations.

I haven't found anything only how people deal with that.